### PR TITLE
[ovirt_hosted_engine] Add new location for broker.conf

### DIFF
--- a/sos/plugins/ovirt_hosted_engine.py
+++ b/sos/plugins/ovirt_hosted_engine.py
@@ -53,6 +53,7 @@ class OvirtHostedEngine(Plugin, RedHatPlugin):
             '/etc/ovirt-hosted-engine-ha/broker-log.conf',
             '/etc/ovirt-hosted-engine-ha/notifications/state_transition.txt',
             '/var/run/ovirt-hosted-engine-ha/vm.conf',
+            '/var/lib/ovirt-hosted-engine-ha/broker.conf',
         ])
 
         all_setup_logs = glob.glob(self.SETUP_LOG_GLOB)


### PR DESCRIPTION
From ovirt 3.6, also broker.conf is in the shared storage
and not under /etc/ovirt-hosted-engine-ha/broker.conf
ha keeps a local copy of broker.conf under
/var/lib/ovirt-hosted-engine-ha/
which is preiodically extracted from the shared storage.
Including /var/lib/ovirt-hosted-engine-ha/broker.conf
in the list of files to be collected.